### PR TITLE
Optimize ESPHome display refresh and caching

### DIFF
--- a/aqmonitor1.yaml
+++ b/aqmonitor1.yaml
@@ -180,21 +180,26 @@ display:
     color_order: bgr # CHANGE THIS if your screen has colors mapped wrong
     color_palette: 8BIT
     invert_colors: false
+    update_interval: 5s
     lambda: |-
-      it.fill(Color::BLACK);
-      // Please forgive me. I know this is horrible spaghetti code, but for now it gets the job done. Will eventually move all this to LVGL. 
-      ;
+      static bool initial = true;
+      static float prev_particles[3] = {NAN, NAN, NAN};
+      static float prev_co2_vals[3] = {NAN, NAN, NAN};
+      static float prev_voc_vals[3] = {NAN, NAN, NAN};
+      static float prev_aqi_voc = NAN;
+      static float prev_aqi_nox = NAN;
+      static float prev_temp_f = NAN;
+      static float prev_hum = NAN;
+      if (initial) {
+        it.fill(Color::BLACK);
+        initial = false;
+      }
       auto cy = 0; // current Y position
-      auto ix = 0; // current X grid position
       auto fv30 = id(font_value_30);
       auto fh36 = id(font_heading_36);
       auto fl14 = id(font_label_14);
-      ;
       auto w = it.get_width();
-      auto h = it.get_height();
-      ;
       auto col = id(white);
-      ;
       auto co2 = id(co2_scd40).state;
       auto e_co2 = id(eco2_ens160).state;
       auto s_co2 = id(eco2_sgp30).state;
@@ -206,11 +211,26 @@ display:
       auto pm10 = id(pm10_pms).state;
       auto aqi_voc = id(aqi_voc_sgp41).state;
       auto aqi_nox = id(aqi_nox_sgp41).state;
-      ;
-      ;
-      ;
+      // helper to draw a row of three values
+      auto draw_row = [&](int cy, const char *title, const char *unit,
+                          const char *names[3], const float values[3],
+                          const Color colors[3], bool show_unit = true) {
+        it.fill_rect(0, cy, w, 88, Color::BLACK);
+        it.line(0, cy, w, cy, id(white));
+        it.print(2, cy + 22, fh36, id(blue), TextAlign::CENTER_LEFT, title);
+        if (show_unit) {
+          it.print(w-2, cy + 31, fl14, id(grey), TextAlign::CENTER_RIGHT, unit);
+        }
+        int ix = 0;
+        for (int i = 0; i < 3; i++) {
+          if (isnan(values[i])) continue;
+          it.printf(w/6*(1+ix*2), cy + 58, fl14, id(grey), TextAlign::BOTTOM_CENTER, "%s", names[i]);
+          it.printf(w/6*(1+ix*2), cy + 50, fv30, colors[i], display::TextAlign::TOP_CENTER, "%.0f", values[i]);
+          ix++;
+        }
+      };
+
       // SET COLOR FOR EACH READING
-      ;
       col = id(green);
       if (co2 > 700){col = id(yellow);}
       if (co2 > 1000){col = id(orange);}
@@ -281,161 +301,115 @@ display:
       float temp = 0;
       float hum = 0;
       for(int i = 0; i < 5; i++){
-      if(!isnan(temps[i])){temp = temps[i]; break;}
+        if(!isnan(temps[i])){temp = temps[i]; break;}
       }
       for(int i = 0; i < 4; i++){
-      if(!isnan(hums[i])){hum = hums[i]; break;}
+        if(!isnan(hums[i])){hum = hums[i]; break;}
       }
-      ;
-      // DRAW HUMITEMP
+      // DRAW HUMITEMP ONLY IF CHANGED
       float temp_f = temp * 1.8 + 32;
-      it.printf(90, 30, fl14, id(grey), TextAlign::BOTTOM_LEFT, "°F");
-      it.printf(90, 34, fv30, white, display::TextAlign::BOTTOM_RIGHT, "%.1f", temp_f);
-      it.printf(197, 18, fl14, id(grey), TextAlign::BOTTOM_LEFT, "RH");
-      it.print(197, 30, fl14, id(grey), TextAlign::BOTTOM_LEFT, "\%");
-      it.printf(197, 34, fv30, white, display::TextAlign::BOTTOM_RIGHT, "%.1f", hum);
-      ;
-      ;
+      if (temp_f != prev_temp_f) {
+        it.fill_rect(60, 0, 80, 40, Color::BLACK);
+        it.printf(90, 30, fl14, id(grey), TextAlign::BOTTOM_LEFT, "°F");
+        it.printf(90, 34, fv30, white, display::TextAlign::BOTTOM_RIGHT, "%.1f", temp_f);
+        prev_temp_f = temp_f;
+      }
+      if (hum != prev_hum) {
+        it.fill_rect(150, 0, 90, 40, Color::BLACK);
+        it.printf(197, 18, fl14, id(grey), TextAlign::BOTTOM_LEFT, "RH");
+        it.print(197, 30, fl14, id(grey), TextAlign::BOTTOM_LEFT, "%");
+        it.printf(197, 34, fv30, white, display::TextAlign::BOTTOM_RIGHT, "%.1f", hum);
+        prev_hum = hum;
+      }
+
       // PREPARE VARIABLES
-      auto title = "";
-      auto unit = "";
       const char *names[3];
       float values[3];
-      esphome::Color colors[3];
-      int count = 0;
-      ;
-      ;
+      Color colors[3];
       // PREPARE PARTICLES
       cy = 30;
-      ;
       if (!isnan(pm1)){
-      count = 0;
-      title = "Particles";
-      unit = "µg/m³";
-      names[0] = "PM1";
-      names[1] = "PM2.5";
-      names[2] = "PM10"; //god C++ sucks
-      values[0] = pm1;
-      values[1] = pm25;
-      values[2] = pm10;
-      colors[0] = pm1_c;
-      colors[1] = pm25_c;
-      colors[2] = pm10_c;
-      ;
-      ;
-      // START REUSABLE
-      it.line(0,cy,w,cy,id(white));
-      it.print(2, cy + 22, fh36, id(blue), TextAlign::CENTER_LEFT, title);
-      it.print(w-2, cy + 31, fl14, id(grey), TextAlign::CENTER_RIGHT, unit);
-      ix = 0;
-      for (int i = 0; i < 3; i++){
-      if(isnan(values[i])){continue;}
-      it.printf(w/6*(1+ix*2), cy + 58, fl14, id(grey), TextAlign::BOTTOM_CENTER, "%s", names[i]);
-      it.printf(w/6*(1+ix*2), cy + 50, fv30, colors[i], display::TextAlign::TOP_CENTER, "%.0f", values[i]);
-      ix++;
+        names[0] = "PM1";
+        names[1] = "PM2.5";
+        names[2] = "PM10";
+        values[0] = pm1;
+        values[1] = pm25;
+        values[2] = pm10;
+        colors[0] = pm1_c;
+        colors[1] = pm25_c;
+        colors[2] = pm10_c;
+        bool changed = false;
+        for (int i = 0; i < 3; i++) if (values[i] != prev_particles[i]) changed = true;
+        if (changed) {
+          draw_row(cy, "Particles", "µg/m³", names, values, colors);
+          for (int i = 0; i < 3; i++) prev_particles[i] = values[i];
+        }
+        cy += 88;
       }
-      // END REUSABLE
-      ;
-      cy += 88;
-      }
-      ;
-      // END PARTICLES
-      ;
       // PREPARE CO2
-      ;
-      if (!isnan(co2) or !isnan(e_co2) or !isnan(s_co2)){
-      count = 0;
-      title = "CO2";
-      unit = "ppm";
-      names[0] = "SCD40";
-      names[1] = "ENS160 est.";
-      names[2] = "SGP30 est.";
-      values[0] = co2;
-      values[1] = e_co2;
-      values[2] = s_co2;
-      colors[0] = co2_c;
-      colors[1] = e_co2_c;
-      colors[2] = s_co2_c;
-      ;
-      ;
-      // START REUSABLE
-      it.line(0,cy,w,cy,id(white));
-      it.print(2, cy + 22, fh36, id(blue), TextAlign::CENTER_LEFT, title);
-      it.print(w-2, cy + 31, fl14, id(grey), TextAlign::CENTER_RIGHT, unit);
-      ix = 0;
-      for (int i = 0; i < 3; i++){
-      if(isnan(values[i])){continue;}
-      it.printf(w/6*(1+ix*2), cy + 58, fl14, id(grey), TextAlign::BOTTOM_CENTER, "%s", names[i]);
-      it.printf(w/6*(1+ix*2), cy + 50, fv30, colors[i], display::TextAlign::TOP_CENTER, "%.0f", values[i]);
-      ix++;
+      if (!isnan(co2) || !isnan(e_co2) || !isnan(s_co2)){
+        names[0] = "SCD40";
+        names[1] = "ENS160 est.";
+        names[2] = "SGP30 est.";
+        values[0] = co2;
+        values[1] = e_co2;
+        values[2] = s_co2;
+        colors[0] = co2_c;
+        colors[1] = e_co2_c;
+        colors[2] = s_co2_c;
+        bool changed = false;
+        for (int i = 0; i < 3; i++) if (values[i] != prev_co2_vals[i]) changed = true;
+        if (changed) {
+          draw_row(cy, "CO2", "ppm", names, values, colors);
+          for (int i = 0; i < 3; i++) prev_co2_vals[i] = values[i];
+        }
+        cy += 88;
       }
-      // END REUSABLE
-      ;
-      ;
-      cy += 88;
-      }
-      ;
-      // END CO2
-      ;
       // PREPARE VOC
-      ;
-      bool draw_general_voc = (!isnan(ch2o) or !isnan(e_voc) or !isnan(s_voc));
-      bool draw_sgp4x = (!isnan(aqi_voc) or !isnan(aqi_nox));
-      if (draw_general_voc or draw_sgp4x){
-      count = 0;
-      title = "VOC";
-      unit = "ppb";
-      names[0] = "SGP30";
-      names[1] = "ENS160";
-      names[2] = "ZE08-CH2O";
-      values[0] = s_voc;
-      values[1] = e_voc;
-      values[2] = ch2o;
-      colors[0] = s_voc_c;
-      colors[1] = e_voc_c;
-      colors[2] = ch2o_c;
-      ;
-      ;
-      // START REUSABLE | UNIT CONDITION ADDED
-      it.line(0,cy,w,cy,id(white));
-      it.print(2, cy + 22, fh36, id(blue), TextAlign::CENTER_LEFT, title);
-      if (draw_general_voc){it.print(w-2, cy + 31, fl14, id(grey), TextAlign::CENTER_RIGHT, unit);}
-      ix = 0;
-      for (int i = 0; i < 3; i++){
-      if(isnan(values[i])){continue;}
-      it.printf(w/6*(1+ix*2), cy + 58, fl14, id(grey), TextAlign::BOTTOM_CENTER, "%s", names[i]);
-      it.printf(w/6*(1+ix*2), cy + 50, fv30, colors[i], display::TextAlign::TOP_CENTER, "%.0f", values[i]);
-      ix++;
+      bool draw_general_voc = (!isnan(ch2o) || !isnan(e_voc) || !isnan(s_voc));
+      bool draw_sgp4x = (!isnan(aqi_voc) || !isnan(aqi_nox));
+      if (draw_general_voc) {
+        names[0] = "SGP30";
+        names[1] = "ENS160";
+        names[2] = "ZE08-CH2O";
+        values[0] = s_voc;
+        values[1] = e_voc;
+        values[2] = ch2o;
+        colors[0] = s_voc_c;
+        colors[1] = e_voc_c;
+        colors[2] = ch2o_c;
+        bool changed = false;
+        for (int i = 0; i < 3; i++) if (values[i] != prev_voc_vals[i]) changed = true;
+        if (changed) {
+          draw_row(cy, "VOC", "ppb", names, values, colors);
+          for (int i = 0; i < 3; i++) prev_voc_vals[i] = values[i];
+        }
+        cy += 88;
       }
-      // END REUSABLE
-      ;
-      ;
-      if (draw_general_voc){cy += 88;}
-      else {cy += 46;}
+      if (draw_sgp4x) {
+        int start_y = cy + 2;
+        bool changed = (aqi_voc != prev_aqi_voc) || (aqi_nox != prev_aqi_nox);
+        if (changed) {
+          it.fill_rect(0, start_y, w, 40, Color::BLACK);
+          auto sgp4x = "SGP41";
+          if (isnan(aqi_nox)) { sgp4x = "SGP40"; }
+          if(!isnan(aqi_voc)){
+            col = id(white);
+            it.printf(2, start_y, fl14, id(grey), TextAlign::CENTER_LEFT, "%s VOC Index", sgp4x);
+            it.printf(180, start_y, fl14, id(grey), TextAlign::CENTER_LEFT, "(1 ... 500)");
+            it.printf(180, start_y, fl14, col, TextAlign::CENTER_RIGHT, "%.0f ", aqi_voc);
+            start_y += 15;
+          }
+          if(!isnan(aqi_nox)){
+            col = id(white);
+            it.printf(2, start_y, fl14, id(grey), TextAlign::CENTER_LEFT, "%s NOx Index", sgp4x);
+            it.printf(180, start_y, fl14, id(grey), TextAlign::CENTER_LEFT, "(1 ... 500)");
+            it.printf(180, start_y, fl14, col, TextAlign::CENTER_RIGHT, "%.0f ", aqi_nox);
+          }
+          prev_aqi_voc = aqi_voc;
+          prev_aqi_nox = aqi_nox;
+        }
       }
-      // START SGP4x
-      cy+=2;
-      auto sgp4x = "SGP41";
-      if (isnan(aqi_nox)){sgp4x = "SGP40";}
-      if(!isnan(aqi_voc)){
-      col = id(white);
-      it.printf(2, cy, fl14, id(grey), TextAlign::CENTER_LEFT, "%s VOC Index", sgp4x);
-      it.printf(180, cy, fl14, id(grey), TextAlign::CENTER_LEFT, "(1 ... 500)");
-      it.printf(180, cy, fl14, col, TextAlign::CENTER_RIGHT, "%.0f ", aqi_voc);
-      cy+=15;
-      }
-      ;
-      if(!isnan(aqi_nox)){
-      col = id(white);
-      it.printf(2, cy, fl14, id(grey), TextAlign::CENTER_LEFT, "%s NOx Index", sgp4x);
-      it.printf(180, cy, fl14, id(grey), TextAlign::CENTER_LEFT, "(1 ... 500)");
-      it.printf(180, cy, fl14, col, TextAlign::CENTER_RIGHT, "%.0f ", aqi_nox);
-      }
-      ;
-      // END VOC & SGP4x
-      ;
-      ;
-      ;
     dimensions:
       height: 320
       width: 240


### PR DESCRIPTION
## Summary
- Slow down the ILI9341 screen refresh to 5s and avoid full-screen redraws
- Cache previous sensor values and redraw only rows that change
- Factor repeated row drawing into a reusable helper

## Testing
- `esphome config aqmonitor1.yaml` *(fails: Could not download gfonts due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1dadb350832baee09d03a74ac089