### PR TITLE
Preserve sensor readings on LCD between updates

### DIFF
--- a/aqmonitor1.yaml
+++ b/aqmonitor1.yaml
@@ -295,39 +295,12 @@ display:
       auto pm10_c = col;
       ;
       ;
-      // SELECT BEST AVAILABLE TEMPERATURE SENSOR
-      float temps[5] = {id(temp_sht40).state, id(temp_aht20_c).state, id(temp_scd40).state, id(temp_aht20_ens).state, id(temp_bmp280).state};
-      float hums[4] = {id(hum_sht40).state, id(hum_aht20).state, id(hum_scd40).state, id(hum_aht20_ens).state};
-      float temp = 0;
-      float hum = 0;
-      for(int i = 0; i < 5; i++){
-        if(!isnan(temps[i])){temp = temps[i]; break;}
-      }
-      for(int i = 0; i < 4; i++){
-        if(!isnan(hums[i])){hum = hums[i]; break;}
-      }
-      // DRAW HUMITEMP ONLY IF CHANGED
-      float temp_f = temp * 1.8 + 32;
-      if (temp_f != prev_temp_f) {
-        it.filled_rectangle(60, 0, 80, 40, Color::BLACK);
-        it.printf(90, 30, fl14, id(grey), TextAlign::BOTTOM_LEFT, "°F");
-        it.printf(90, 34, fv30, white, display::TextAlign::BOTTOM_RIGHT, "%.1f", temp_f);
-        prev_temp_f = temp_f;
-      }
-      if (hum != prev_hum) {
-        it.filled_rectangle(150, 0, 90, 40, Color::BLACK);
-        it.printf(197, 18, fl14, id(grey), TextAlign::BOTTOM_LEFT, "RH");
-        it.print(197, 30, fl14, id(grey), TextAlign::BOTTOM_LEFT, "%");
-        it.printf(197, 34, fv30, white, display::TextAlign::BOTTOM_RIGHT, "%.1f", hum);
-        prev_hum = hum;
-      }
-
       // PREPARE VARIABLES
       const char *names[3];
       float values[3];
       Color colors[3];
       // PREPARE PARTICLES
-      cy = 30;
+      cy = 40;
       if (!isnan(pm1)){
         names[0] = "PM1";
         names[1] = "PM2.5";
@@ -339,13 +312,17 @@ display:
         colors[1] = pm25_c;
         colors[2] = pm10_c;
         bool changed = false;
-        for (int i = 0; i < 3; i++) if (values[i] != prev_particles[i]) changed = true;
-        if (changed) {
+        bool has_valid = false;
+        for (int i = 0; i < 3; i++) {
+          if (!isnan(values[i])) has_valid = true;
+          if (values[i] != prev_particles[i]) changed = true;
+        }
+        if (changed && has_valid) {
           draw_row(cy, "Particles", "µg/m³", names, values, colors);
           for (int i = 0; i < 3; i++) prev_particles[i] = values[i];
         }
-        cy += 88;
       }
+      cy += 88;
       // PREPARE CO2
       if (!isnan(co2) || !isnan(e_co2) || !isnan(s_co2)){
         names[0] = "SCD40";
@@ -358,8 +335,12 @@ display:
         colors[1] = e_co2_c;
         colors[2] = s_co2_c;
         bool changed = false;
-        for (int i = 0; i < 3; i++) if (values[i] != prev_co2_vals[i]) changed = true;
-        if (changed) {
+        bool has_valid = false;
+        for (int i = 0; i < 3; i++) {
+          if (!isnan(values[i])) has_valid = true;
+          if (values[i] != prev_co2_vals[i]) changed = true;
+        }
+        if (changed && has_valid) {
           draw_row(cy, "CO2", "ppm", names, values, colors);
           for (int i = 0; i < 3; i++) prev_co2_vals[i] = values[i];
         }
@@ -379,8 +360,12 @@ display:
         colors[1] = e_voc_c;
         colors[2] = ch2o_c;
         bool changed = false;
-        for (int i = 0; i < 3; i++) if (values[i] != prev_voc_vals[i]) changed = true;
-        if (changed) {
+        bool has_valid = false;
+        for (int i = 0; i < 3; i++) {
+          if (!isnan(values[i])) has_valid = true;
+          if (values[i] != prev_voc_vals[i]) changed = true;
+        }
+        if (changed && has_valid) {
           draw_row(cy, "VOC", "ppb", names, values, colors);
           for (int i = 0; i < 3; i++) prev_voc_vals[i] = values[i];
         }
@@ -408,6 +393,36 @@ display:
           }
           prev_aqi_voc = aqi_voc;
           prev_aqi_nox = aqi_nox;
+        }
+      }
+      // SELECT BEST AVAILABLE TEMPERATURE SENSOR
+      float temps[5] = {id(temp_sht40).state, id(temp_aht20_c).state, id(temp_scd40).state, id(temp_aht20_ens).state, id(temp_bmp280).state};
+      float hums[4] = {id(hum_sht40).state, id(hum_aht20).state, id(hum_scd40).state, id(hum_aht20_ens).state};
+      float temp = NAN;
+      float hum = NAN;
+      for(int i = 0; i < 5; i++){
+        if(!isnan(temps[i])){temp = temps[i]; break;}
+      }
+      for(int i = 0; i < 4; i++){
+        if(!isnan(hums[i])){hum = hums[i]; break;}
+      }
+      // DRAW HUMITEMP ONLY IF CHANGED
+      if (!isnan(temp)) {
+        float temp_f = temp * 1.8 + 32;
+        if (temp_f != prev_temp_f) {
+          it.filled_rectangle(60, 0, 80, 40, Color::BLACK);
+          it.printf(90, 30, fl14, id(grey), TextAlign::BOTTOM_LEFT, "°F");
+          it.printf(90, 34, fv30, white, display::TextAlign::BOTTOM_RIGHT, "%.1f", temp_f);
+          prev_temp_f = temp_f;
+        }
+      }
+      if (!isnan(hum)) {
+        if (hum != prev_hum) {
+          it.filled_rectangle(150, 0, 90, 40, Color::BLACK);
+          it.printf(197, 18, fl14, id(grey), TextAlign::BOTTOM_LEFT, "RH");
+          it.print(197, 30, fl14, id(grey), TextAlign::BOTTOM_LEFT, "%");
+          it.printf(197, 34, fv30, white, display::TextAlign::BOTTOM_RIGHT, "%.1f", hum);
+          prev_hum = hum;
         }
       }
     dimensions:


### PR DESCRIPTION
## Summary
- Only clear and redraw particle/CO₂/VOC rows when fresh valid values arrive
- Draw temperature and humidity after other sections to keep them visible during row refreshes

## Testing
- `esphome config aqmonitor1.yaml` *(fails: Error reading file secrets.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f9623788832bacec07a541980dcf